### PR TITLE
Add OTEL OTLP headers configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,7 @@ OTEL_SERVICE_NAME=aisdr-bot
 OTEL_SERVICE_VERSION=1.0.0
 OTEL_ENVIRONMENT=production
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
+OTEL_EXPORTER_OTLP_HEADERS={"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}
 
 # Observe.inc Integration (if using Observe)
 OBSERVE_INGEST_TOKEN=your_observe_ingest_token_here

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export OTEL_SERVICE_NAME=aisdr-bot
 export OTEL_SERVICE_VERSION=1.0.0
 export OTEL_ENVIRONMENT=production
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
+export OTEL_EXPORTER_OTLP_HEADERS='{"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}'
 
 # For Observe.inc integration
 export OBSERVE_INGEST_TOKEN=<your_observe_ingest_token>

--- a/test_instrumentation.py
+++ b/test_instrumentation.py
@@ -52,7 +52,12 @@ def test_otel_setup():
 def test_environment():
     """Test environment variable configuration."""
     required_vars = ["SLACK_BOT_TOKEN", "OPENAI_API_KEY"]
-    optional_vars = ["OBSERVE_INGEST_TOKEN", "OTEL_SERVICE_NAME", "OTEL_ENVIRONMENT"]
+    optional_vars = [
+        "OBSERVE_INGEST_TOKEN",
+        "OTEL_SERVICE_NAME",
+        "OTEL_ENVIRONMENT",
+        "OTEL_EXPORTER_OTLP_HEADERS",
+    ]
     
     print("\n🔧 Environment Variables:")
     for var in required_vars:


### PR DESCRIPTION
## Summary
- add json parsing for `OTEL_EXPORTER_OTLP_HEADERS` in `otel_setup`
- document OTEL headers env var in README and `.env.example`
- validate OTEL headers env var in test script

## Testing
- `python -m py_compile aisdr.py otel_setup.py test_instrumentation.py`
- `python test_instrumentation.py` *(fails: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_6866cc10dde0832aa23a7086e771f571