### PR TITLE
Fix OTLP exporter config instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ OTEL_SERVICE_VERSION=1.0.0
 OTEL_ENVIRONMENT=production
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
 OTEL_EXPORTER_OTLP_HEADERS={"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}
+OTEL_TRACES_EXPORTER=otlp
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # Observe.inc Integration (if using Observe)
 OBSERVE_INGEST_TOKEN=your_observe_ingest_token_here

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Install the Python dependencies listed in `requirements.txt`:
 pip install -r requirements.txt
 ```
 
+This installs the OTLP HTTP exporter required for tracing. If the package is missing, you'll see errors like `ModuleNotFoundError: No module named 'opentelemetry.exporter'`.
+
 Key libraries include Flask, requests, slack_sdk, openai and comprehensive OpenTelemetry instrumentation.
 
 ## Configuration
@@ -42,6 +44,8 @@ export OTEL_SERVICE_VERSION=1.0.0
 export OTEL_ENVIRONMENT=production
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
 export OTEL_EXPORTER_OTLP_HEADERS='{"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}'
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # For Observe.inc integration
 export OBSERVE_INGEST_TOKEN=<your_observe_ingest_token>


### PR DESCRIPTION
## Summary
- document running `pip install -r requirements.txt`
- document required OTLP environment variables in README and `.env.example`

## Testing
- `python test_instrumentation.py` *(fails: No module named 'opentelemetry')*

------
https://chatgpt.com/codex/tasks/task_e_6866f2128aa4832ab269b7b50f291325