### PR TITLE
Add OTLP log exporter and per-signal headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ OTEL_SERVICE_NAME=aisdr-bot
 OTEL_SERVICE_VERSION=1.0.0
 OTEL_ENVIRONMENT=production
 OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
-OTEL_EXPORTER_OTLP_HEADERS={"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}
+OTEL_EXPORTER_OTLP_HEADERS={"Authorization":"Bearer <YOUR_INGEST_TOKEN>"}
 OTEL_TRACES_EXPORTER=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,23 @@ export OTEL_SERVICE_NAME=aisdr-bot
 export OTEL_SERVICE_VERSION=1.0.0
 export OTEL_ENVIRONMENT=production
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.observe.inc/v1/otel
-export OTEL_EXPORTER_OTLP_HEADERS='{"Authorization":"Bearer <YOUR_INGEST_TOKEN>","x-observe-target-package":"Tracing"}'
+export OTEL_EXPORTER_OTLP_HEADERS='{"Authorization":"Bearer <YOUR_INGEST_TOKEN>"}'
 export OTEL_TRACES_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # For Observe.inc integration
 export OBSERVE_INGEST_TOKEN=<your_observe_ingest_token>
+```
+
+The application automatically sets the `x-observe-target-package` header for each
+signal:
+
+- Traces: `Tracing`
+- Metrics: `Metrics`
+- Logs: `Host Explorer`
+
+So you only need to provide the `Authorization` token in
+`OTEL_EXPORTER_OTLP_HEADERS`.
 ```
 
 Copy `.env.example` to `.env` and configure your values:


### PR DESCRIPTION
## Summary
- configure OTLP log exporter and LoggerProvider
- add helper for OTLP headers to set target package
- set package headers for traces, metrics and logs
- document new header handling and update env examples

## Testing
- `python test_instrumentation.py`

------
https://chatgpt.com/codex/tasks/task_e_686772cefb1c832ab538d375d37a7b69