### PR TITLE
Update doc and log observe token override

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 # For Observe.inc integration
 export OBSERVE_INGEST_TOKEN=<your_observe_ingest_token>
+
+# When set, `OBSERVE_INGEST_TOKEN` replaces any token defined via
+# `OTEL_EXPORTER_OTLP_HEADERS` or `OTEL_EXPORTER_OTLP_AUTH_HEADER`. Make sure
+# this token grants access to Tracing, Metrics and Logs, or unset it if you want
+# to rely solely on `OTEL_EXPORTER_OTLP_AUTH_HEADER`.
 ```
 
 The application automatically sets the `x-observe-target-package` header for each

--- a/otel_setup.py
+++ b/otel_setup.py
@@ -89,6 +89,10 @@ def get_otlp_headers(package: str) -> dict:
 
     observe_token = os.getenv("OBSERVE_INGEST_TOKEN")
     if observe_token:
+        if "Authorization" in otlp_headers and otlp_headers["Authorization"] != f"Bearer {observe_token}":
+            logging.info(
+                "OBSERVE_INGEST_TOKEN overrides Authorization header defined by other variables"
+            )
         otlp_headers["Authorization"] = f"Bearer {observe_token}"
 
     otlp_headers["x-observe-target-package"] = package

--- a/test_instrumentation.py
+++ b/test_instrumentation.py
@@ -57,6 +57,7 @@ def test_environment():
         "OTEL_SERVICE_NAME",
         "OTEL_ENVIRONMENT",
         "OTEL_EXPORTER_OTLP_HEADERS",
+        "OTEL_EXPORTER_OTLP_AUTH_HEADER",
     ]
     
     print("\n🔧 Environment Variables:")


### PR DESCRIPTION
## Summary
- clarify README that OBSERVE_INGEST_TOKEN overrides other OTLP tokens
- show `OTEL_EXPORTER_OTLP_AUTH_HEADER` in env report
- log when OBSERVE_INGEST_TOKEN replaces the Authorization header

## Testing
- `python test_instrumentation.py`

------
https://chatgpt.com/codex/tasks/task_e_68679905f604832abce86ce07663a59c