### PR TITLE
Add OTLP header logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ signal:
 
 So you only need to provide the `Authorization` token using either
 `OTEL_EXPORTER_OTLP_HEADERS` or `OTEL_EXPORTER_OTLP_AUTH_HEADER`.
+
+For troubleshooting, AISDR logs the OTLP headers it builds at startup,
+including the value of `x-observe-target-package` for each signal.
 ```
 
 Copy `.env.example` to `.env` and configure your values:

--- a/otel_setup.py
+++ b/otel_setup.py
@@ -96,6 +96,12 @@ def get_otlp_headers(package: str) -> dict:
         otlp_headers["Authorization"] = f"Bearer {observe_token}"
 
     otlp_headers["x-observe-target-package"] = package
+
+    masked_headers = {
+        k: ("<masked>" if k.lower() == "authorization" else v)
+        for k, v in otlp_headers.items()
+    }
+    logging.info("OTLP headers for %s: %s", package, masked_headers)
     return otlp_headers
 
 def setup_tracing() -> trace.Tracer:


### PR DESCRIPTION
## Summary
- log the complete OTLP header set (with Authorization masked)
- document header logging in README

## Testing
- `pip install -r requirements.txt`
- `python test_instrumentation.py`

------
https://chatgpt.com/codex/tasks/task_e_6867a0b08888832a96f375c2cb681a2e