### PR TITLE
Ensure OTLP headers log correctly

### DIFF
--- a/otel_setup.py
+++ b/otel_setup.py
@@ -291,14 +291,14 @@ def setup_observability(app) -> tuple[trace.Tracer, metrics.Meter, dict]:
     Returns:
         Tuple of (tracer, meter, custom_metrics)
     """
+    # Set up logging first so log records have trace context
+    setup_logging()
+
     # Set up tracing
     tracer = setup_tracing()
-    
+
     # Set up metrics
     meter = setup_metrics()
-    
-    # Set up logging
-    setup_logging()
     
     # Instrument the application
     instrument_application(app)


### PR DESCRIPTION
## Summary
- log OTLP headers after logging instrumentation is configured
- keep info message showing the headers

## Testing
- `python test_instrumentation.py`

------
https://chatgpt.com/codex/tasks/task_e_6867a3814990832ab227445524c5bf75